### PR TITLE
C port: Fix issue with uninitialized mp_writepos

### DIFF
--- a/source_gba/mm_mixer_gba_c.c
+++ b/source_gba/mm_mixer_gba_c.c
@@ -144,6 +144,8 @@ void mmMixerInit(mm_gba_system *setup)
 
     mm_wavebuffer = (uintptr_t)setup->wave_memory;
 
+    mp_writepos = mm_wavebuffer;
+
     mm_word mode = setup->mixing_mode;
 
     // round(rate / 59.737)


### PR DESCRIPTION
This should be fixed in the asm version as well, until that is supported.

Fixes bad writes until the second call of mmVblank.