### PR TITLE
Use calloc in gba init to prevent dirty buffer from introducing errors

### DIFF
--- a/source_gba/mm_init_default.s
+++ b/source_gba/mm_init_default.s
@@ -59,7 +59,8 @@ mmInitDefault:
 	mul	r0, r6
 	ldr	r4,=mixlen
 	add	r0, r4
-	bl	malloc
+	mov	r1, #1
+	bl	calloc
 	
 	mov	r7, r0				// wavemem = beginning of buffer
 	add	r3, r0, r4			// split up buffer into addresses [r3,r4,r5]


### PR DESCRIPTION
Does what it says on the tin. If you boot a GBA game with everdrive quick boot, it will fail. Does not apply to NDS code.