### PR TITLE
LLVM support: replace non-standard ".struct" directive

### DIFF
--- a/asm_include/mp_defs.inc
+++ b/asm_include/mp_defs.inc
@@ -24,17 +24,16 @@
 @ other definitions
 #ifdef SYS_GBA
 
-.struct 0
-MM_GBA_SYSTEM_MODE:		.space 4
-MM_GBA_SYSTEM_MCH_COUNT:	.space 4
-MM_GBA_SYSTEM_ACH_COUNT:	.space 4
-MM_GBA_SYSTEM_MODCH:		.space 4
-MM_GBA_SYSTEM_ACTCH:		.space 4
-MM_GBA_SYSTEM_MIXCH:		.space 4
-MM_GBA_SYSTEM_MIXMEM:		.space 4
-MM_GBA_SYSTEM_WAVEMEM:		.space 4
-MM_GBA_SYSTEM_SOUNDBANK:	.space 4
-MM_GBA_SYSTEM_SIZE:
+.equ MM_GBA_SYSTEM_MODE,	0
+.equ MM_GBA_SYSTEM_MCH_COUNT,	MM_GBA_SYSTEM_MODE	+ 4
+.equ MM_GBA_SYSTEM_ACH_COUNT,	MM_GBA_SYSTEM_MCH_COUNT	+ 4
+.equ MM_GBA_SYSTEM_MODCH,	MM_GBA_SYSTEM_ACH_COUNT	+ 4
+.equ MM_GBA_SYSTEM_ACTCH,	MM_GBA_SYSTEM_MODCH	+ 4
+.equ MM_GBA_SYSTEM_MIXCH,	MM_GBA_SYSTEM_ACTCH	+ 4
+.equ MM_GBA_SYSTEM_MIXMEM,	MM_GBA_SYSTEM_MIXCH	+ 4
+.equ MM_GBA_SYSTEM_WAVEMEM,	MM_GBA_SYSTEM_MIXMEM	+ 4
+.equ MM_GBA_SYSTEM_SOUNDBANK,	MM_GBA_SYSTEM_WAVEMEM	+ 4
+.equ MM_GBA_SYSTEM_SIZE,	MM_GBA_SYSTEM_SOUNDBANK + 4
 
 .equ		SAMPFRAC,		12	@ # of bits used in fractional part of sample reading
 #endif
@@ -55,22 +54,22 @@ MM_GBA_SYSTEM_SIZE:
 .equ	MPCB_SONGMESSAGE	,0x2A	@ gba/nds7 song playback
 .equ	MPCB_SONGFINISHED	,0x2B	@ gba/nds7
 
-.struct 0
-mms_rate:	.space 4
-mms_len:	.space 4
-mms_function:	.space 4
-mms_format:	.space 4
-mms_timer:	.space 4
-mms_manual:	.space 1
-mms_size:
+.equ mms_rate,		0
+.equ mms_len,		mms_rate	+ 4
+.equ mms_function,	mms_len		+ 4
+.equ mms_format,	mms_function	+ 4
+.equ mms_timer,		mms_format	+ 4
+.equ mms_manual,	mms_timer	+ 4
+.equ mms_size,		mms_manual	+ 1
 
-.struct 0				// reverb cfg struct
-mmrc_flags:		.space 4
-mmrc_memory:		.space 4
-mmrc_delay:		.space 2
-mmrc_rate:		.space 2
-mmrc_feedback:		.space 2
-mmrc_panning:		.space 1
+// reverb cfg structure
+.equ mmrc_flags,	0
+.equ mmrc_memory,	mmrc_flags	+ 4
+.equ mmrc_delay,	mmrc_memory	+ 4
+.equ mmrc_rate,		mmrc_delay	+ 2
+.equ mmrc_feedback,	mmrc_rate	+ 2
+.equ mmrc_panning,	mmrc_feedback	+ 2
+// mmrc_panning is length 1
 
 .equ	MMRFS_MEMORY,		0
 .equ	MMRFS_DELAY,		1

--- a/source/mm_effect.s
+++ b/source/mm_effect.s
@@ -33,13 +33,13 @@
  *
  ***********************************************************************/
 
-.struct 0					// mm_sound_effect
-MM_SFX_SOURCE:	.space 4			// word: source
-MM_SFX_RATE:	.space 2			// hword: rate
-MM_SFX_HANDLE:	.space 2			// byte:  handle
-MM_SFX_VOLUME:	.space 1			// byte:  volume
-MM_SFX_PANNING:	.space 1			// byte:  panning
-MM_SFX_SIZE:					// 8 bytes total
+// offsets of structure "mm_sound_effect"
+.equ MM_SFX_SOURCE,	0			// word: source
+.equ MM_SFX_RATE,	MM_SFX_SOURCE	+ 4	// hword: rate
+.equ MM_SFX_HANDLE,	MM_SFX_RATE	+ 2	// byte:  handle
+.equ MM_SFX_VOLUME,	MM_SFX_HANDLE	+ 2	// byte:  volume
+.equ MM_SFX_PANNING,	MM_SFX_VOLUME	+ 1	// byte:  panning
+.equ MM_SFX_SIZE,	MM_SFX_PANNING	+ 1 	// 8 bytes total
 
 .equ	channelCount, 16
 .equ	releaseLevel, 200

--- a/source/mm_mas.s
+++ b/source/mm_mas.s
@@ -1305,7 +1305,7 @@ mppProcessTick:					@@      @@@ @    @@
 						@@  @@@@@@@    @@@
 						@@@@@@@@@@@@@@@@@
 
-	add	r0,pc,#0			// switch to ARM to preserve regs
+	mov	r0,pc				// switch to ARM to preserve regs
 	bx	r0				//
 .arm						//
 	stmfd	sp!, {lr}			//

--- a/source_ds/mm_stream.s
+++ b/source_ds/mm_stream.s
@@ -31,25 +31,27 @@
 	.equ	TIMER_AUTO,	0b11000011	// start, irq, /1024
 	.equ	TIMER_MANUAL,	0b10000011	// start, /1024
 	
-	.struct 0
-v_active:		.space 1
-v_format:		.space 1
-v_auto:			.space 1
-v_reserved:		.space 1
-v_clks:			.space 2
-v_tmr:			.space 2
-v_len:			.space 2
-v_lenw:			.space 2
-v_pos:			.space 2
-v_reserved2:		.space 2
-v_hwtimer:		.space 4
-v_wave:			.space 4
-v_workmem:		.space 4
-v_function:		.space 4
-v_remainder:		.space 4
 
-v_size:
-
+// structure
+//			preceding field + length of preceding field
+//			ie "v_active + 1" means v_active has a length of 1
+//
+.equ v_active,		0
+.equ v_format,		v_active	+ 1
+.equ v_auto,		v_format	+ 1
+.equ v_reserved,	v_auto		+ 1
+.equ v_clks,		v_reserved	+ 1
+.equ v_tmr,		v_clks		+ 2
+.equ v_len,		v_tmr		+ 2
+.equ v_lenw,		v_len		+ 2
+.equ v_pos,		v_lenw		+ 2
+.equ v_reserved2,	v_pos		+ 2
+.equ v_hwtimer,		v_reserved2	+ 2
+.equ v_wave,		v_hwtimer	+ 4
+.equ v_workmem,		v_wave		+ 4
+.equ v_function,	v_workmem	+ 4
+.equ v_remainder,	v_function	+ 4
+.equ v_size,		v_remainder	+ 4
 
 /***********************************************************************
  *

--- a/source_ds7/mm_mixer_super.s
+++ b/source_ds7/mm_mixer_super.s
@@ -158,26 +158,19 @@ mm_mix_data:
 .equ	MB_FETCH_SIZE	,(256)
 .equ	MB_FETCH_PADDING,(32)
 
-@----------------------------------------------------------
-.struct 0
-@----------------------------------------------------------
-MB_SH_VLEVEL:			// next volume level
-MB_SH_VMUL:	.space 1	//
-MB_SH_VSHIFT:	.space 1	//
-MB_SH_PLEVEL:	.space 1	// next panning level
-MB_SH_RESERVED:	.space 1	//
-MB_SH_LEN:			//
+// structure
+.equ MB_SH_VLEVEL,	0			// next volume level
+.equ MB_SH_VMUL,	MB_SH_VLEVEL	+ 0
+.equ MB_SH_VSHIFT,	MB_SH_VMUL	+ 1
+.equ MB_SH_PLEVEL,	MB_SH_VSHIFT	+ 1	// next panning level
+.equ MB_SH_RESERVED,	MB_SH_PLEVEL	+ 1
+.equ MB_SH_LEN,		MB_SH_RESERVED	+ 1
 
-@----------------------------------------------------------
-.struct	0
-@----------------------------------------------------------
-MB_OUTPUT:
-	.space 16*512		// 512 bytes/channel (128 samples, double-buffered)
-MB_FETCH:
-	.space MB_FETCH_SIZE+MB_FETCH_PADDING
-MB_SHADOW:
-	.space MB_SH_LEN*16
-MB_LEN:
+// structure
+.equ MB_OUTPUT,		0				// 512 bytes/channel (128 samples, double-buffered)
+.equ MB_FETCH,		MB_OUTPUT	+ (16*512)
+.equ MB_SHADOW,		MB_FETCH + (MB_FETCH_SIZE+MB_FETCH_PADDING)
+.equ MB_LEN,		MB_SHADOW + (MB_SH_LEN*16)
 
 @**********************************************************
 @ MODE C [sw mixing]
@@ -186,25 +179,22 @@ MB_LEN:
 .equ	MC_FETCH_SIZE	,(256)
 .equ	MC_FETCH_PADDING,(16)
 
-@----------------------------------------------------------
-.struct	0			// mode C - shadow data
-@----------------------------------------------------------
-MC_SH_CNT:	.space 4	// CNT updated every tick -locked
-				// top 8 bits only updated on new source
-				
-MC_SH_SRC:	.space 4	// SRC
-MC_SH_TMR:	.space 2	// TMR updated every tick   
-MC_SH_PNT:	.space 2	// PNT } updated if SRC != 0
-MC_SH_LEN:	.space 4	// LEN } (SRC cleared after)
-MC_SH_SIZE:			// (length of struct)
+// structure		mode C - shadow data
+.equ MC_SH_CNT,		0			// CNT updated every tick -locked
+						// top 8 bits only updated on new source
+						//
+.equ MC_SH_SRC,		MC_SH_CNT	+ 4	// SRC
+.equ MC_SH_TMR,		MC_SH_SRC	+ 4	// TMR updated every tick
+.equ MC_SH_PNT,		MC_SH_TMR	+ 2	// PNT } updated if SRC != 0
+.equ MC_SH_LEN,		MC_SH_PNT	+ 2	// LEN } (SRC cleared after)
+.equ MC_SH_SIZE,	MC_SH_LEN	+ 4	// (length of struct)
 
-@----------------------------------------------------------
-.struct 0
-@----------------------------------------------------------
-MC_MIX_OUTPUT:	.space MM_SW_BUFFERLEN*4		// 16-bit stereo
-MC_MIX_WMEM:	.space MM_SW_CHUNKLEN*4			// (working buffer)
-MC_FETCH:	.space MC_FETCH_SIZE+MC_FETCH_PADDING
-MC_SHADOW:	.space MC_SH_LEN*16
+// structure
+.equ MC_MIX_OUTPUT,	0					// 16-bit stereo
+.equ MC_MIX_WMEM,	MC_MIX_OUTPUT 	+ MM_SW_BUFFERLEN*4	// (working buffer)
+.equ MC_FETCH,		MC_MIX_WMEM 	+ MM_SW_CHUNKLEN*4
+.equ MC_SHADOW,		MC_FETCH 	+ MC_FETCH_SIZE+MC_FETCH_PADDING
+// length of MC_SHADOW: MC_SH_LEN*16
 @----------------------------------------------------------
 
 .if MC_SH_CNT != 0
@@ -1365,7 +1355,7 @@ mmMixChunk:
 	
 	ldrh	sfreq, [rch, #C_FREQ]		// read frequency
 	ldr	r0,=49212			// adjust scale (32khz -> 21khz)
-	mul	sfreq, r0			//
+	mul	sfreq, r0, sfreq		//
 	lsr	sfreq, #15			//
 	
 	ldr	sread, [rch, #C_READ]		// get sample position

--- a/source_ds9/mm_comms.s
+++ b/source_ds9/mm_comms.s
@@ -124,13 +124,13 @@ F: SELECTMODE		2	[mode]				select audio mode
 
 .equ	EFFECT_CHANNELS,	16
 
-.struct 0					// mm_sound_effect
-MM_SFX_SRC:	.space 4			// hword: source
-MM_SFX_RATE:	.space 2			// hword: rate
-MM_SFX_HANDLE:	.space 2			// byte:  handle
-MM_SFX_VOLUME:	.space 2			// hword: volume
-MM_SFX_PANNING:	.space 1			// byte:  panning
-MM_SFX_SIZE:
+// offsets of structure "mm_sound_effect"
+.equ 	MM_SFX_SRC,	0			// hword: source
+.equ 	MM_SFX_RATE,	MM_SFX_SRC	+ 4	// hword: rate
+.equ 	MM_SFX_HANDLE,	MM_SFX_RATE	+ 2	// byte:  handle
+.equ 	MM_SFX_VOLUME,	MM_SFX_HANDLE	+ 2	// hword: volume
+.equ 	MM_SFX_PANNING,	MM_SFX_VOLUME	+ 2	// byte:  panning
+.equ 	MM_SFX_SIZE,	MM_SFX_PANNING	+ 1
 
 //----------------------------------------------------------------------
 	.bss

--- a/source_ds9/mm_main9.s
+++ b/source_ds9/mm_main9.s
@@ -18,11 +18,11 @@
 
 .equ	FIFO_MAXMOD,	3
 
-.struct 0		// mm_ds9_system
-MMDS9S_MOD_COUNT:	.space 4
-MMDS9S_SAMP_COUNT:	.space 4
-MMDS9S_MEM_BANK:	.space 4
-MMDS9S_FIFO_CHANNEL:	.space 4
+// offsets of structure "mm_ds9_system"
+.equ MMDS9S_MOD_COUNT,		0
+.equ MMDS9S_SAMP_COUNT,		MMDS9S_MOD_COUNT	+ 4
+.equ MMDS9S_MEM_BANK,		MMDS9S_SAMP_COUNT	+ 4
+.equ MMDS9S_FIFO_CHANNEL,	MMDS9S_MEM_BANK		+ 4
 
 //-----------------------------------------------------------------------------
 	.bss


### PR DESCRIPTION
This replaces the `.struct` directives (a GNU extension) with `.equ`, which works more universally (i.e. LLVM's assembler). From my understanding they generate equivalent code.

I checked each folder under the build directory with the following commands, running on Linux:

```sh
# Get a build before and after this PR

# Only run these once, on latest master, before this PR
make
cp -R build/ build-old/
# apply patches from this PR, then...
make
```

```sh
# loops over each folder in ./build (which is found from find build | grep -Eo "^[^/]+/[^/]+/[^/]+$" | grep -Eo "/[^/]+/[^/]+$")
# then loops over every file in that folder
# then objdump's each file from the ./build-old directory and the ./build directory with -D (--disassemble-all)
# then runs `diff` with the old one and the new one
for FOLDER in $(find build | grep -Eo "^[^/]+/[^/]+/[^/]+$" | grep -Eo "/[^/]+/[^/]+$"); do for F in $(find ./build/$FOLDER | grep -Eo "/[^/]+\.o+$"); do arm-none-eabi-objdump -D ./build-old/$FOLDER/$F > /tmp/old && arm-none-eabi-objdump -D ./build/$FOLDER/$F > /tmp/current && diff /tmp/old /tmp/current --color=always; done; done
```

Or in a more readable fashion:

```sh
# fancy way of finding all folders exactly 2 levels deep (eg build/ds9/source_ds but not build/ds9)
for FOLDER in $(find build | grep -Eo "^[^/]+/[^/]+/[^/]+$" | grep -Eo "/[^/]+/[^/]+$")
do
    # fancy way of writing "all files ending with .o"
    for F in $(find ./build/$FOLDER | grep -Eo "/[^/]+\.o+$")
    do
        arm-none-eabi-objdump -D ./build-old/$FOLDER/$F > /tmp/old
            && arm-none-eabi-objdump -D ./build/$FOLDER/$F > /tmp/current
            && diff /tmp/old /tmp/current --color=always
    done
done

```

This is the only difference reported:

```diff
< ./build-old/ds7/source/mm_mas.s.o:     file format elf32-littlearm
---
> ./build/ds7/source/mm_mas.s.o:     file format elf32-littlearm
537c537
<      424:	a000      	add	r0, pc, #0	@ (adr r0, 428 <mppProcessTick+0x4>)
---
>      424:	4678      	mov	r0, pc
```
