### PR TITLE
mm_soundbank.c: fix classical memory leak

### DIFF
--- a/source/ds/arm9/mm_memory.c
+++ b/source/ds/arm9/mm_memory.c
@@ -63,8 +63,8 @@ void mmUnload(mm_word module_ID)
         mmUnloadEffect(((mm_mas_sample_info*)(sample_table[i] + ((mm_word)header)))->msl_id);
 
     // Free module
-    mmModuleBankArr[module_ID] = 0;
     mmcbMemory(MMCB_DELETESONG, mmModuleBankArr[module_ID]);
+    mmModuleBankArr[module_ID] = 0;
 
     // Flush the Bank
     mmFlushBank();

--- a/source/ds/arm9/mm_soundbank.c
+++ b/source/ds/arm9/mm_soundbank.c
@@ -96,6 +96,7 @@ static mm_word mmsHandleFileOp(mm_word msg, mm_word param)
         case MMCB_SAMPREQUEST:
             retval = mmLoadDataFromSoundBank(param, 1);
             break;
+        case MMCB_DELETESONG:
         case MMCB_DELETESAMPLE:
             free((mm_addr)param);
             break;


### PR DESCRIPTION
This is a very classical bug that existed in Maxmod for many years but got fixed in dkP's Calico update. Let's fix it here too!

Note that the callsite currently sets the pointer to 0 before calling `MMCB_DELETESONG`. That's also fixed in this PR.

Cross-ref fixed code in Calico https://github.com/devkitPro/maxmod/blob/master/source_calico/mm_loader.c#L214-L219