### PR TITLE
core: remove always_inline attribute from mas.h functions

### DIFF
--- a/source/core/mas.h
+++ b/source/core/mas.h
@@ -58,21 +58,22 @@ mm_word mpp_Update_ACHN_notest(mpl_layer_information *layer, mm_active_channel *
 
 void mpp_Channel_NewNote(mm_module_channel*, mpl_layer_information*);
 
-static inline __attribute__((always_inline))
+
+static inline
 mm_mas_sample_info *mpp_SamplePointer(mpl_layer_information *layer, mm_word sampleN)
 {
     mm_byte *base = (mm_byte *)layer->songadr;
     return (mm_mas_sample_info *)(base + layer->samptable[sampleN - 1]);
 }
 
-static inline __attribute__((always_inline))
+static inline
 mm_mas_instrument *mpp_InstrumentPointer(mpl_layer_information *layer, mm_word instN)
 {
     mm_byte *base = (mm_byte *)layer->songadr;
     return (mm_mas_instrument*)(base + layer->insttable[instN - 1]);
 }
 
-static inline __attribute__((always_inline))
+static inline
 mm_mas_pattern *mpp_PatternPointer(mpl_layer_information *layer, mm_word entry)
 {
     mm_byte *base = (mm_byte *)layer->songadr;


### PR DESCRIPTION
Fixes these errors on clang:

```c
/home/galaxyshard/projects/ds/maxmod-fork/source/core/mas_arm.c:430:38: error: always_inline function 'mpp_SamplePointer' requires target feature 'thumb-mode', but would be inlined into function 'mmUpdateChannel_T0' that is compiled without support for 'thumb-mode'
        mm_mas_sample_info *sample = mpp_SamplePointer(mpp_layer, act_ch->sample);
                                     ^
/home/galaxyshard/projects/ds/maxmod-fork/source/core/mas_arm.c:453:45: error: always_inline function 'mpp_InstrumentPointer' requires target feature 'thumb-mode', but would be inlined into function 'mmUpdateChannel_T0' that is compiled without support for 'thumb-mode'
            mm_mas_instrument *instrument = mpp_InstrumentPointer(mpp_layer, module_channel->inst);
                                            ^
/home/galaxyshard/projects/ds/maxmod-fork/source/core/mas_arm.c:472:42: error: always_inline function 'mpp_SamplePointer' requires target feature 'thumb-mode', but would be inlined into function 'mmUpdateChannel_T0' that is compiled without support for 'thumb-mode'
            mm_mas_sample_info *sample = mpp_SamplePointer(mpp_layer, act_ch->sample);
```
