### PR TITLE
Move mmUpdateChannel_TN out of IWRAM

### DIFF
--- a/source/core/mas_arm.c
+++ b/source/core/mas_arm.c
@@ -523,7 +523,6 @@ channel_started:
 
 // For ticks that are not the first one. Note that mpp_layer->ticks may be zero
 // when this function is called (if a channel is active and the row increases).
-IWRAM_CODE ARM_CODE
 void mmUpdateChannel_TN(mm_module_channel *module_channel, mpl_layer_information *mpp_layer)
 {
     // Get channel, if available


### PR DESCRIPTION
This does not appear to be necessary WRT performance. Tested in Apotris with both wireless multiplayer and our CPU-intensive bot code running at the same time on real hardware (a very CPU heavy setup we don't actually see in real world play).

This saves a massive amount of IWRAM and now reduces the total memory usage of the program to less than maxmod used in the assembly codebase.